### PR TITLE
Support for Lower Left Key with either a . (period) key or a 00 (double zero) key

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ Container(
           )
 ```
 
+#### Show Numeric keyboard with default view (And a Double Zero lower left key)
+```dart
+Container(
+            // Keyboard is transparent
+            color: Colors.red,
+            child: VirtualKeyboard(
+                // [0-9] + .
+                type: VirtualKeyboardType.Numeric,
+                // Callback for key press event
+                onKeyPress: (key) => print(key.text),
+                lowerLeftKeyType: NumberLowerLeftKeyType.DoubleZero)
+            ),
+          )
+```
+
 #### Show Alphanumeric keyboard with customized keys
 
 ```dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,7 +45,7 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             Text(
               text,
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.displayLarge,
             ),
             SwitchListTile(
               title: Text(
@@ -72,7 +72,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   type: isNumericMode
                       ? VirtualKeyboardType.Numeric
                       : VirtualKeyboardType.Alphanumeric,
-                  onKeyPress: _onKeyPress),
+                  onKeyPress: _onKeyPress,
+                  lowerLeftKeyType: NumberLowerLeftKeyType.DoubleZero),
             )
           ],
         ),

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -29,6 +29,9 @@ class VirtualKeyboard extends StatefulWidget {
   /// Set to true if you want only to show Caps letters.
   final bool alwaysCaps;
 
+  /// used to place either a . (period) or a 00 (double zero) in the lower left key.
+  final NumberLowerLeftKeyType lowerLeftKeyType;
+
   VirtualKeyboard(
       {Key key,
       @required this.type,
@@ -37,7 +40,8 @@ class VirtualKeyboard extends StatefulWidget {
       this.height = _virtualKeyboardDefaultHeight,
       this.textColor = Colors.black,
       this.fontSize = 14,
-      this.alwaysCaps = false})
+      this.alwaysCaps = false,
+      this.lowerLeftKeyType = NumberLowerLeftKeyType.Period})
       : super(key: key);
 
   @override
@@ -62,6 +66,8 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
   // True if shift is enabled.
   bool isShiftEnabled = false;
 
+  NumberLowerLeftKeyType lowerLeftKeyType;
+
   @override
   void didUpdateWidget(Widget oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -72,6 +78,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
       textColor = widget.textColor;
       fontSize = widget.fontSize;
       alwaysCaps = widget.alwaysCaps;
+      lowerLeftKeyType = widget.lowerLeftKeyType;
 
       // Init the Text Style for keys.
       textStyle = TextStyle(
@@ -91,6 +98,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     textColor = widget.textColor;
     fontSize = widget.fontSize;
     alwaysCaps = widget.alwaysCaps;
+    lowerLeftKeyType = widget.lowerLeftKeyType;
 
     // Init the Text Style for keys.
     textStyle = TextStyle(
@@ -133,7 +141,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     // Get the keyboard Rows
     List<List<VirtualKeyboardKey>> keyboardRows =
         type == VirtualKeyboardType.Numeric
-            ? _getKeyboardRowsNumeric()
+            ? _getKeyboardRowsNumeric(lowerLeftKeyType)
             : _getKeyboardRows();
 
     // Generate keyboard row.

--- a/lib/src/rows.dart
+++ b/lib/src/rows.dart
@@ -62,8 +62,8 @@ const List<List> _keyRows = [
   ]
 ];
 
-/// Keys for Virtual Keyboard's rows.
-const List<List> _keyRowsNumeric = [
+/// Keys for Virtual Keyboard's rows with a period in the lower left row.
+const List<List> _keyRowsNumericPeriod = [
   // Row 1
   const [
     '1',
@@ -89,20 +89,64 @@ const List<List> _keyRowsNumeric = [
   ],
 ];
 
-/// Returns a list of `VirtualKeyboardKey` objects for Numeric keyboard.
-List<VirtualKeyboardKey> _getKeyboardRowKeysNumeric(rowNum) {
-  // Generate VirtualKeyboardKey objects for each row.
-  return List.generate(_keyRowsNumeric[rowNum].length, (int keyNum) {
-    // Get key string value.
-    String key = _keyRowsNumeric[rowNum][keyNum];
+/// Keys for Virtual Keyboard's rows with a double zeros in the lower left row.
+const List<List> _keyRowsNumericDoubleZero = [
+  // Row 1
+  const [
+    '1',
+    '2',
+    '3',
+  ],
+  // Row 1
+  const [
+    '4',
+    '5',
+    '6',
+  ],
+  // Row 1
+  const [
+    '7',
+    '8',
+    '9',
+  ],
+  // Row 1
+  const [
+    '00',
+    '0',
+  ],
+];
 
-    // Create and return new VirtualKeyboardKey object.
-    return VirtualKeyboardKey(
-      text: key,
-      capsText: key.toUpperCase(),
-      keyType: VirtualKeyboardKeyType.String,
-    );
-  });
+
+/// Returns a list of `VirtualKeyboardKey` objects for Numeric keyboard.
+List<VirtualKeyboardKey> _getKeyboardRowKeysNumeric(int rowNum, NumberLowerLeftKeyType lowerLeftKeyType) {
+  // Generate VirtualKeyboardKey objects for each row.
+
+  switch (lowerLeftKeyType) {
+    case NumberLowerLeftKeyType.Period:
+      return List.generate(_keyRowsNumericPeriod[rowNum].length, (int keyNum) {
+        // Get key string value.
+        String key = _keyRowsNumericPeriod[rowNum][keyNum];
+
+        // Create and return new VirtualKeyboardKey object.
+        return VirtualKeyboardKey(
+          text: key,
+          capsText: key.toUpperCase(),
+          keyType: VirtualKeyboardKeyType.String,
+        );
+      });
+    case NumberLowerLeftKeyType.DoubleZero:
+      return List.generate(_keyRowsNumericDoubleZero[rowNum].length, (int keyNum) {
+        // Get key string value.
+        String key = _keyRowsNumericDoubleZero[rowNum][keyNum];
+
+        // Create and return new VirtualKeyboardKey object.
+        return VirtualKeyboardKey(
+          text: key,
+          capsText: key.toUpperCase(),
+          keyType: VirtualKeyboardKeyType.String,
+        );
+      });
+  }
 }
 
 /// Returns a list of `VirtualKeyboardKey` objects.
@@ -195,10 +239,19 @@ List<List<VirtualKeyboardKey>> _getKeyboardRows() {
   });
 }
 
+int _listNumericLength(NumberLowerLeftKeyType lowerLeftKeyType) {
+  switch (lowerLeftKeyType) {
+    case NumberLowerLeftKeyType.Period:
+      return _keyRowsNumericPeriod.length;
+    case NumberLowerLeftKeyType.DoubleZero:
+      return _keyRowsNumericDoubleZero.length;
+  }
+}
+
 /// Returns a list of VirtualKeyboard rows with `VirtualKeyboardKey` objects.
-List<List<VirtualKeyboardKey>> _getKeyboardRowsNumeric() {
+List<List<VirtualKeyboardKey>> _getKeyboardRowsNumeric(NumberLowerLeftKeyType lowerLeftKeyType) {
   // Generate lists for each keyboard row.
-  return List.generate(_keyRowsNumeric.length, (int rowNum) {
+  return List.generate(_listNumericLength(lowerLeftKeyType), (int rowNum) {
     // Will contain the keyboard row keys.
     List<VirtualKeyboardKey> rowKeys = [];
 
@@ -206,7 +259,7 @@ List<List<VirtualKeyboardKey>> _getKeyboardRowsNumeric() {
     switch (rowNum) {
       case 3:
         // String keys.
-        rowKeys.addAll(_getKeyboardRowKeysNumeric(rowNum));
+        rowKeys.addAll(_getKeyboardRowKeysNumeric(rowNum, lowerLeftKeyType));
 
         // Right Shift
         rowKeys.add(
@@ -216,7 +269,7 @@ List<List<VirtualKeyboardKey>> _getKeyboardRowsNumeric() {
         );
         break;
       default:
-        rowKeys = _getKeyboardRowKeysNumeric(rowNum);
+        rowKeys = _getKeyboardRowKeysNumeric(rowNum, lowerLeftKeyType);
     }
 
     return rowKeys;

--- a/lib/src/type.dart
+++ b/lib/src/type.dart
@@ -4,3 +4,8 @@ part of virtual_keyboard;
 /// `Numeric` - Numeric only.
 /// `Alphanumeric` - Alphanumeric: letters`[A-Z]` + numbers`[0-9]` + `@` + `.`.
 enum VirtualKeyboardType { Numeric, Alphanumeric }
+
+/// If using the Numeric keypad, you can pass in the DoubleZero to get a 00 key like a cash drawer page.
+/// Period is the default Key.
+///
+enum NumberLowerLeftKeyType { Period, DoubleZero }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Gurgen Hovhannisyan <g.hovhannisyan@digitalpomegranate.com>
 homepage: https://github.com/gurgenDP/virtual_keyboard
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: virtual_keyboard
+name: new_virtual_keyboard
 description: A simple package for dispaying virtual keyboards on a devices like kiosks and ATMs. The library is written in Dart and has no native code dependancy. 
 version: 0.1.4
 author: Gurgen Hovhannisyan <g.hovhannisyan@digitalpomegranate.com>


### PR DESCRIPTION
This is a quick pull request for a new feature that I would like to include. If needed, I can add a sample usage. Basically, you can pass an additional optional parameter in that uses an enum to pass the option of either Period or DoubleZero